### PR TITLE
Adding continuous integration

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+      working-directory: ./Backend
+    - name: Build with Gradle
+      run: ./gradlew build
+      working-directory: ./Backend
+    


### PR DESCRIPTION

Adding Continuous integration
Following this doc to setup
[https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle]

might want to change to values of `distribution`